### PR TITLE
Pandoc find-and-replace feature

### DIFF
--- a/Citer.sublime-settings
+++ b/Citer.sublime-settings
@@ -1,0 +1,3 @@
+{
+"pandoc_cite_fix": true
+}

--- a/citer.py
+++ b/citer.py
@@ -49,6 +49,7 @@ def plugin_loaded():
     global COMPLETIONS_SCOPES
     global ENABLE_COMPLETIONS
     global _EXCLUDE
+    global PANDOC_FIX
 
     settings = sublime.load_settings('Citer.sublime-settings')
     BIBFILE_PATH = settings.get('bibtex_file_path')
@@ -58,12 +59,19 @@ def plugin_loaded():
     CITATION_FORMAT = settings.get('citation_format', "@%s")
     COMPLETIONS_SCOPES = settings.get('completions_scopes', ['text.html.markdown'])
     ENABLE_COMPLETIONS = settings.get('enable_completions', True)
+    PANDOC_FIX = settings.get('pandoc_cite_fix', False)
     _EXCLUDE = settings.get('hide_other_completions', True)
     refresh_caches()
 
 
 def plugin_unloaded():
     pass
+
+class FindReplaceBracketCommand(sublime_plugin.TextCommand):
+    def run(self, edit):
+        lstpos = self.view.find_all(r'\]\[')
+        for i, pos in reversed(list(enumerate(lstpos))):
+            self.view.replace(edit, pos, r'; ')
 
 
 def refresh_caches():
@@ -155,7 +163,11 @@ class CiterSearchCommand(sublime_plugin.TextCommand):
         ent = self.current_results_list[item]
         ent = ent.split(' ')[0]
         citekey = CITATION_FORMAT % ent
-        self.view.run_command('insert', {'characters': citekey})
+        if PANDOC_FIX:
+            self.view.run_command('insert', {'characters': citekey})
+            self.view.run_command('find_replace_bracket')
+        else:
+            self.view.run_command('insert', {'characters': citekey})
 
 
 class CiterShowKeysCommand(sublime_plugin.TextCommand):
@@ -184,7 +196,11 @@ class CiterShowKeysCommand(sublime_plugin.TextCommand):
         ent = self.current_results_list[item][0]
         ent = ent.split(' ')[0]
         citekey = CITATION_FORMAT % ent
-        self.view.run_command('insert', {'characters': citekey})
+        if PANDOC_FIX:
+            self.view.run_command('insert', {'characters': citekey})
+            self.view.run_command('find_replace_bracket')
+        else:
+            self.view.run_command('insert', {'characters': citekey})
 
 
 class CiterGetTitleCommand(sublime_plugin.TextCommand):


### PR DESCRIPTION
Hi there,

I found your stuff (Citer & AcademicMd) last week, and I have already gotten a ton of use out of it. I thought I'd show my appreciation by contribution to development - I hope you don't mind. This is the first of two pull requests. Since it's not possible to make a list of citations before adding them, this feature (if the user turns it on) will replace all of the ][ created by two Pandoc citations butting up against each other with `; ` so that it's properly formatted as multiple citations. So:

```
[@Callon:1998td][@MacKenzie:2006uy]
```

becomes 

```
[@Callon:1998td; @MacKenzie:2006uy]
```

automatically as each new cite is added.