### PR TITLE
Author parse and quickview display feature

### DIFF
--- a/Citer.sublime-settings
+++ b/Citer.sublime-settings
@@ -1,0 +1,4 @@
+    {
+    // Can be any combination of {author}, {title} and {citekey}; passing extra arguments via .format is (AFAIK) harmless.
+    "quickview_format": "{author} - {title} - {citekey}"
+}


### PR DESCRIPTION
Here's feature two. This creates a user-settable option for QUICKVIEW_FORMAT in settings. If the user's quickview includes `author`, the author name is formatted as follows in the Quick Pane:

- Single Author: Lastname
- Two Authors: Lastname1 and Lastname2
- Three or More Authors: Lastname 1 et al.

As far as I can tell, passing more arguments in str.format() does nothing, so if the user doesn't specify all three parameters everything still works. 

Here's a photo of what my Quick Pane looks like with this implemented:
![screen shot 2015-02-22 at 7 54 40 pm](https://cloud.githubusercontent.com/assets/1239829/6321496/bb0530ba-bacc-11e4-8042-de522b550281.png)
