### PR TITLE
Fixes misleading install.txt to align with the main README

### DIFF
--- a/messages/install.txt
+++ b/messages/install.txt
@@ -18,7 +18,7 @@ See below for example configuration
 {
     //REQUIRED:
 
-    "bibtex_file_path": "example/path/to/file.bib",
+    "bibtex_file": "example/path/to/file.bib",
 
     //OPTIONAL:
 


### PR DESCRIPTION
Updates install.txt (the instructions shown to a user who has just used Package Control to install) in accordance with https://github.com/mangecoeur/Citer/issues/44