### PR TITLE
Reverse Lookup for Citations & Auto-Completion Insertion options

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,18 +12,13 @@
 - **Auto-Completion Insertion Settings**:
   - Added an option to control the format of auto-completion when using Tab/Enter. You can now choose from the following:
 
-    - **CiteKey only**: Inserts only the citation key (e.g., "@gandhi1933").
-    - **Title only**: Inserts only the title (e.g., "Truth, non-violence, and social justice.").
-    - **Both**: Inserts both the citation key and the title (e.g., "@gandhi1933 Truth, non-violence, and social justice.").
+    - "citekey": Inserts only the citation key (e.g., "@gandhi1933").
+    - "title": Inserts only the title (e.g., "Truth, non-violence, and social justice.").
+    - "both": Inserts both the citation key and the title (e.g., "@gandhi1933 Truth, non-violence, and social justice.").
 
-  ```json
-  // Configuration for auto-completion insertion
-  // Options:
-  //   "citekey" - Insert only the citation key (e.g., "@gandhi1933")
-  //   "title"   - Insert only the title (e.g., "Truth, non-violence, and social justice.")
-  //   "both"    - Insert both citation key and title (e.g., "@gandhi1933 "Truth, non-violence, and social justice.")
-  // "completion_type": "citekey",
-  ```
+    ```json
+    "completion_type": "citekey",
+    ```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,32 @@
 # Citations from BibTeX for Sublime Text
 
+---
+
+2025-08-02 15:00
+
+### New Features: 
+
+- **Reverse Lookup for Citations**:
+  - Hover over the citation key in your document to display a popup with the full title, author, and abstract (if available).
+
+- **Auto-Completion Insertion Settings**:
+  - Added an option to control the format of auto-completion when using Tab/Enter. You can now choose from the following:
+
+    - **CiteKey only**: Inserts only the citation key (e.g., "@gandhi1933").
+    - **Title only**: Inserts only the title (e.g., "Truth, non-violence, and social justice.").
+    - **Both**: Inserts both the citation key and the title (e.g., "@gandhi1933 Truth, non-violence, and social justice.").
+
+  ```json
+  // Configuration for auto-completion insertion
+  // Options:
+  //   "citekey" - Insert only the citation key (e.g., "@gandhi1933")
+  //   "title"   - Insert only the title (e.g., "Truth, non-violence, and social justice.")
+  //   "both"    - Insert both citation key and title (e.g., "@gandhi1933 "Truth, non-violence, and social justice.")
+  // "completion_type": "citekey",
+  ```
+
+---
+
 This [Sublime Text 3](https://www.sublimetext.com/3) plugin provides citation search and Tab-completion for citations stored in a BibTeX file. Configure the file path and you are good to go!
 
 The default set up is optimized to work with [AcademicMarkdown](https://github.com/mangecoeur/AcademicMarkdown).

--- a/messages/2.0.0xt
+++ b/messages/2.0.0xt
@@ -1,0 +1,25 @@
+Citer 2.0
+===========
+
+### New Features:
+
+- **Reverse Lookup for Citations**:
+
+  - Hover over the citation key in your document to display a popup with the full title, author, and abstract (if available).
+
+- **Auto-Completion Insertion Settings**:
+
+  - Added an option to control the format of auto-completion when using Tab/Enter. You can now choose from the following:
+
+    - **CiteKey only**: Inserts only the citation key (e.g., "@gandhi1933").
+    - **Title only**: Inserts only the title (e.g., "Truth, non-violence, and social justice.").
+    - **Both**: Inserts both the citation key and the title (e.g., "@gandhi1933 Truth, non-violence, and social justice.").
+
+  ```json
+  // Configuration for auto-completion insertion
+  // Options:
+  //   "citekey" - Insert only the citation key (e.g., "@gandhi1933")
+  //   "title"   - Insert only the title (e.g., "Truth, non-violence, and social justice.")
+  //   "both"    - Insert both citation key and title (e.g., "@gandhi1933 "Truth, non-violence, and social justice.")
+  // "completion_type": "citekey",
+  ```


### PR DESCRIPTION
### New Features: 

- **Reverse Lookup for Citations**:
  - Hover over the citation key in your document to display a popup with the full title, author, and abstract (if available).

- **Auto-Completion Insertion Settings**:
  - Added an option to control the format of auto-completion when using Tab/Enter. You can now choose from the following:

    - "citekey": Inserts only the citation key (e.g., "@gandhi1933").
    - "title": Inserts only the title (e.g., "Truth, non-violence, and social justice.").
    - "both": Inserts both the citation key and the title (e.g., "@gandhi1933 Truth, non-violence, and social justice.").

    ```json
    "completion_type": "citekey",
    ```